### PR TITLE
Update links to reflect new org and repo name

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,6 +1,6 @@
 @misc{entanglement-forging,
   author = {Luciano Bello and Agata M. Bra\'{n}czyk and Sergey Bravyi and Andrew Eddins and Julien Gacon and Tanvi P. Gujarati and Ikko Hamamura and Takashi Imamichi and Caleb Johnson and Ieva Liepuoniute and Mario Motta and Max Rossmannek and Travis L. Scholten and Iskandar Sitdikov and Stefan Woerner},
   title = {Entanglement forging module},
-  howpublished = {\url{https://github.com/IBM-Quantum-prototypes/entanglement-forging}},
+  howpublished = {\url{https://github.com/qiskit-community/prototype-entanglement-forging}},
   year = {2021}
 }

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
   [![Qiskit](https://img.shields.io/badge/Qiskit-%E2%89%A5%200.34.1-6133BD)](https://github.com/Qiskit/qiskit)
   [![Qiskit Nature](https://img.shields.io/badge/Qiskit%20Nature-%E2%89%A5%200.3.0-6133BD)](https://github.com/Qiskit/qiskit-nature)
 <br />
-  [![License](https://img.shields.io/github/license/IBM-Quantum-prototypes/entanglement-forging?label=License)](https://github.com/IBM-Quantum-prototypes/entanglement-forging/blob/main/LICENSE.txt)
-  [![Tests](https://github.com/IBM-Quantum-prototypes/entanglement-forging/actions/workflows/tests.yml/badge.svg)](https://github.com/IBM-Quantum-prototypes/entanglement-forging/actions/workflows/tests.yml)
+  [![License](https://img.shields.io/github/license/qiskit-community/prototype-entanglement-forging?label=License)](https://github.com/qiskit-community/prototype-entanglement-forging/blob/main/LICENSE.txt)
+  [![Tests](https://github.com/qiskit-community/prototype-entanglement-forging/actions/workflows/tests.yml/badge.svg)](https://github.com/qiskit-community/prototype-entanglement-forging/actions/workflows/tests.yml)
 
 </div>
 <!-- PROJECT LOGO -->
 <p align="center">
-  <a href="https://github.com/IBM-Quantum-prototypes/quantum-kernel-training#readme">
+  <a href="https://github.com/qiskit-community/prototype-quantum-kernel-training#readme">
     <img src="docs/images/ef_image.png" alt="Logo" width="600">
   </a>
   <h2 align="center">Entanglement Forging</h2>
 
 <p align="center">
-  <a href="https://mybinder.org/v2/gh/IBM-Quantum-prototypes/entanglement-forging/HEAD?labpath=docs%2F1-tutorials%2Ftutorial_2_H2O_molecule_statevector_simulator.ipynb">
+  <a href="https://mybinder.org/v2/gh/qiskit-community/prototype-entanglement-forging/HEAD?labpath=docs%2F1-tutorials%2Ftutorial_2_H2O_molecule_statevector_simulator.ipynb">
     <img src="https://img.shields.io/badge/launch-demo-579ACA.svg?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFkAAABZCAMAAABi1XidAAAB8lBMVEX///9XmsrmZYH1olJXmsr1olJXmsrmZYH1olJXmsr1olJXmsrmZYH1olL1olJXmsr1olJXmsrmZYH1olL1olJXmsrmZYH1olJXmsr1olL1olJXmsrmZYH1olL1olJXmsrmZYH1olL1olL0nFf1olJXmsrmZYH1olJXmsq8dZb1olJXmsrmZYH1olJXmspXmspXmsr1olL1olJXmsrmZYH1olJXmsr1olL1olJXmsrmZYH1olL1olLeaIVXmsrmZYH1olL1olL1olJXmsrmZYH1olLna31Xmsr1olJXmsr1olJXmsrmZYH1olLqoVr1olJXmsr1olJXmsrmZYH1olL1olKkfaPobXvviGabgadXmsqThKuofKHmZ4Dobnr1olJXmsr1olJXmspXmsr1olJXmsrfZ4TuhWn1olL1olJXmsqBi7X1olJXmspZmslbmMhbmsdemsVfl8ZgmsNim8Jpk8F0m7R4m7F5nLB6jbh7jbiDirOEibOGnKaMhq+PnaCVg6qWg6qegKaff6WhnpKofKGtnomxeZy3noG6dZi+n3vCcpPDcpPGn3bLb4/Mb47UbIrVa4rYoGjdaIbeaIXhoWHmZYHobXvpcHjqdHXreHLroVrsfG/uhGnuh2bwj2Hxk17yl1vzmljzm1j0nlX1olL3AJXWAAAAbXRSTlMAEBAQHx8gICAuLjAwMDw9PUBAQEpQUFBXV1hgYGBkcHBwcXl8gICAgoiIkJCQlJicnJ2goKCmqK+wsLC4usDAwMjP0NDQ1NbW3Nzg4ODi5+3v8PDw8/T09PX29vb39/f5+fr7+/z8/Pz9/v7+zczCxgAABC5JREFUeAHN1ul3k0UUBvCb1CTVpmpaitAGSLSpSuKCLWpbTKNJFGlcSMAFF63iUmRccNG6gLbuxkXU66JAUef/9LSpmXnyLr3T5AO/rzl5zj137p136BISy44fKJXuGN/d19PUfYeO67Znqtf2KH33Id1psXoFdW30sPZ1sMvs2D060AHqws4FHeJojLZqnw53cmfvg+XR8mC0OEjuxrXEkX5ydeVJLVIlV0e10PXk5k7dYeHu7Cj1j+49uKg7uLU61tGLw1lq27ugQYlclHC4bgv7VQ+TAyj5Zc/UjsPvs1sd5cWryWObtvWT2EPa4rtnWW3JkpjggEpbOsPr7F7EyNewtpBIslA7p43HCsnwooXTEc3UmPmCNn5lrqTJxy6nRmcavGZVt/3Da2pD5NHvsOHJCrdc1G2r3DITpU7yic7w/7Rxnjc0kt5GC4djiv2Sz3Fb2iEZg41/ddsFDoyuYrIkmFehz0HR2thPgQqMyQYb2OtB0WxsZ3BeG3+wpRb1vzl2UYBog8FfGhttFKjtAclnZYrRo9ryG9uG/FZQU4AEg8ZE9LjGMzTmqKXPLnlWVnIlQQTvxJf8ip7VgjZjyVPrjw1te5otM7RmP7xm+sK2Gv9I8Gi++BRbEkR9EBw8zRUcKxwp73xkaLiqQb+kGduJTNHG72zcW9LoJgqQxpP3/Tj//c3yB0tqzaml05/+orHLksVO+95kX7/7qgJvnjlrfr2Ggsyx0eoy9uPzN5SPd86aXggOsEKW2Prz7du3VID3/tzs/sSRs2w7ovVHKtjrX2pd7ZMlTxAYfBAL9jiDwfLkq55Tm7ifhMlTGPyCAs7RFRhn47JnlcB9RM5T97ASuZXIcVNuUDIndpDbdsfrqsOppeXl5Y+XVKdjFCTh+zGaVuj0d9zy05PPK3QzBamxdwtTCrzyg/2Rvf2EstUjordGwa/kx9mSJLr8mLLtCW8HHGJc2R5hS219IiF6PnTusOqcMl57gm0Z8kanKMAQg0qSyuZfn7zItsbGyO9QlnxY0eCuD1XL2ys/MsrQhltE7Ug0uFOzufJFE2PxBo/YAx8XPPdDwWN0MrDRYIZF0mSMKCNHgaIVFoBbNoLJ7tEQDKxGF0kcLQimojCZopv0OkNOyWCCg9XMVAi7ARJzQdM2QUh0gmBozjc3Skg6dSBRqDGYSUOu66Zg+I2fNZs/M3/f/Grl/XnyF1Gw3VKCez0PN5IUfFLqvgUN4C0qNqYs5YhPL+aVZYDE4IpUk57oSFnJm4FyCqqOE0jhY2SMyLFoo56zyo6becOS5UVDdj7Vih0zp+tcMhwRpBeLyqtIjlJKAIZSbI8SGSF3k0pA3mR5tHuwPFoa7N7reoq2bqCsAk1HqCu5uvI1n6JuRXI+S1Mco54YmYTwcn6Aeic+kssXi8XpXC4V3t7/ADuTNKaQJdScAAAAAElFTkSuQmCC" alt="Launch Demo">
    </a>
    <a href="https://www.youtube.com/playlist?list=PLOFEBzvs-VvqpCgxSxhKE4gbJiinURVQX">
@@ -55,8 +55,8 @@ Before using the module for new work, users should read through the [reference g
 <!-- HOW TO GIVE FEEDBACK -->
 ### How to Give Feedback
 We encourage your feedback! You can share your thoughts with us by:
-- [Opening an issue](https://github.com/IBM-Quantum-prototypes/entanglement-forging/issues) in the repository
-- [Starting a conversation on GitHub Discussions](https://github.com/IBM-Quantum-prototypes/entanglement-forging/discussions)
+- [Opening an issue](https://github.com/qiskit-community/prototype-entanglement-forging/issues) in the repository
+- [Starting a conversation on GitHub Discussions](https://github.com/qiskit-community/prototype-entanglement-forging/discussions)
 - Filling out our [survey](https://airtable.com/shrFxJXYzjxf5tFvx)
 
 
@@ -64,7 +64,7 @@ We encourage your feedback! You can share your thoughts with us by:
 
 <!-- CONTRIBUTION GUIDELINES -->
 ### Contribution Guidelines
-For information on how to contribute to this project, please take a look at our [CONTRIBUTING.MD](CONTRIBUTING.md) and the [Contribution Guide](https://github.com/IBM-Quantum-prototypes/docs/2-reference-guide/reference_guide.md#contribution-guide) section of the reference guide.
+For information on how to contribute to this project, please take a look at our [CONTRIBUTING.MD](CONTRIBUTING.md) and the [Contribution Guide](https://github.com/qiskit-community/prototype-entanglement-forging/docs/2-reference-guide/reference_guide.md#contribution-guide) section of the reference guide.
 
 
 ----------------------------------------------------------------------------------------------------

--- a/docs/2-reference_guide/reference_guide.md
+++ b/docs/2-reference_guide/reference_guide.md
@@ -238,7 +238,7 @@ This guide is for those who want to extend the module or documentation. If you j
     ```
 2. Within terminal, clone repository:
 ```bash
-git clone https://github.com/IBM-Quantum-prototypes/entanglement-forging.git
+git clone https://github.com/qiskit-community/prototype-entanglement-forging.git
 ```
 3. Change directory to the freshly cloned forging module:
 ```bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = entanglement_forging
 version = 0.0.0
-url = https://github.com/IBM-Quantum-prototypes/entanglement-forging
+url = https://github.com/qiskit-community/prototype-entanglement-forging
 maintainer = Caleb Johnson
 maintainer_email = caleb.johnson@ibm.com
 classifiers =


### PR DESCRIPTION
Update inner-repository links to reflect new org (qiskit-community) and prototype name with prototype prefix.