### PR TITLE
Implement abstract parent methods.

### DIFF
--- a/docs/1-tutorials/tutorial_1_H2_molecule_statevector_simulator.ipynb
+++ b/docs/1-tutorials/tutorial_1_H2_molecule_statevector_simulator.ipynb
@@ -30,6 +30,7 @@
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
   },
@@ -56,7 +57,8 @@
     "from qiskit_nature.converters.second_quantization import QubitConverter\n",
     "\n",
     "import sys\n",
-    "sys.path.append('../../')\n",
+    "\n",
+    "sys.path.append(\"../../\")\n",
     "from entanglement_forging import EntanglementForgedGroundStateSolver\n",
     "from entanglement_forging import EntanglementForgedConfig"
    ]
@@ -81,10 +83,12 @@
    },
    "outputs": [],
    "source": [
-    "molecule = Molecule(geometry=[('H', [0., 0., 0.]),\n",
-    "                              ('H', [0., 0., 0.735])],\n",
-    "                     charge=0, multiplicity=1)\n",
-    "driver = PySCFDriver.from_molecule(molecule = molecule)\n",
+    "molecule = Molecule(\n",
+    "    geometry=[(\"H\", [0.0, 0.0, 0.0]), (\"H\", [0.0, 0.0, 0.735])],\n",
+    "    charge=0,\n",
+    "    multiplicity=1,\n",
+    ")\n",
+    "driver = PySCFDriver.from_molecule(molecule=molecule)\n",
     "problem = ElectronicStructureProblem(driver)\n",
     "problem.second_q_ops()\n",
     "\n",
@@ -118,13 +122,18 @@
     }
    ],
    "source": [
-    "from qiskit_nature.algorithms.ground_state_solvers import GroundStateEigensolver, NumPyMinimumEigensolverFactory\n",
+    "from qiskit_nature.algorithms.ground_state_solvers import (\n",
+    "    GroundStateEigensolver,\n",
+    "    NumPyMinimumEigensolverFactory,\n",
+    ")\n",
     "\n",
-    "solver = GroundStateEigensolver(converter, NumPyMinimumEigensolverFactory(use_default_filter_criterion=False))\n",
+    "solver = GroundStateEigensolver(\n",
+    "    converter, NumPyMinimumEigensolverFactory(use_default_filter_criterion=False)\n",
+    ")\n",
     "\n",
     "result = solver.solve(problem)\n",
     "\n",
-    "print('Classical energy = ', result.total_energies[0])"
+    "print(\"Classical energy = \", result.total_energies[0])"
    ]
   },
   {
@@ -175,9 +184,9 @@
     }
    ],
    "source": [
-    "bitstrings = [[1,0],[0,1]]\n",
+    "bitstrings = [[1, 0], [0, 1]]\n",
     "\n",
-    "ansatz = TwoLocal(2, [], 'cry', [[0,1],[1,0]], reps=1)\n",
+    "ansatz = TwoLocal(2, [], \"cry\", [[0, 1], [1, 0]], reps=1)\n",
     "\n",
     "ansatz.draw()"
    ]
@@ -211,9 +220,12 @@
    "outputs": [],
    "source": [
     "from qiskit import Aer\n",
-    "backend = Aer.get_backend('statevector_simulator')\n",
     "\n",
-    "config = EntanglementForgedConfig(backend=backend, maxiter = 200, initial_params=[0,0.5*np.pi])"
+    "backend = Aer.get_backend(\"statevector_simulator\")\n",
+    "\n",
+    "config = EntanglementForgedConfig(\n",
+    "    backend=backend, maxiter=200, initial_params=[0, 0.5 * np.pi]\n",
+    ")"
    ]
   },
   {
@@ -329,14 +341,14 @@
     }
    ],
    "source": [
-    "print('Energies (from only one paramset in each iteration):')\n",
+    "print(\"Energies (from only one paramset in each iteration):\")\n",
     "plt.plot([e[0] for e in res.get_energies_history()])\n",
     "plt.plot([e[1] for e in res.get_energies_history()[0:-1]])\n",
     "plt.show()\n",
-    "print('Schmidts (from only one paramset in each iteration):')\n",
+    "print(\"Schmidts (from only one paramset in each iteration):\")\n",
     "plt.plot([s[0] for s in res.get_schmidts_history()])\n",
     "plt.show()\n",
-    "print('Parameters (from only one paramset in each iteration):')\n",
+    "print(\"Parameters (from only one paramset in each iteration):\")\n",
     "plt.plot([p[0] for p in res.get_parameters_history()])\n",
     "plt.plot([p[1] for p in res.get_parameters_history()[0:-1]])\n",
     "plt.show()"
@@ -374,6 +386,7 @@
    ],
    "source": [
     "import qiskit.tools.jupyter\n",
+    "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
    ]

--- a/docs/1-tutorials/tutorial_2_H2O_molecule_statevector_simulator.ipynb
+++ b/docs/1-tutorials/tutorial_2_H2O_molecule_statevector_simulator.ipynb
@@ -31,6 +31,7 @@
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
   },
@@ -51,7 +52,8 @@
     "from qiskit import Aer\n",
     "\n",
     "import sys\n",
-    "sys.path.append('../../')\n",
+    "\n",
+    "sys.path.append(\"../../\")\n",
     "from entanglement_forging import EntanglementForgedGroundStateSolver\n",
     "from entanglement_forging import EntanglementForgedConfig"
    ]
@@ -76,13 +78,19 @@
     "thetas_in_deg = 104.478  # bond angles.\n",
     "\n",
     "H1_x = radius_1\n",
-    "H2_x = radius_2*np.cos(np.pi/180 * thetas_in_deg)\n",
-    "H2_y = radius_2*np.sin(np.pi/180 * thetas_in_deg)\n",
+    "H2_x = radius_2 * np.cos(np.pi / 180 * thetas_in_deg)\n",
+    "H2_y = radius_2 * np.sin(np.pi / 180 * thetas_in_deg)\n",
     "\n",
-    "molecule = Molecule(geometry=[['O', [0., 0., 0.]],\n",
-    "                              ['H', [H1_x, 0., 0.]],\n",
-    "                              ['H', [H2_x, H2_y, 0.0]]], charge=0, multiplicity=1)\n",
-    "driver = PySCFDriver.from_molecule(molecule = molecule, basis='sto6g')\n",
+    "molecule = Molecule(\n",
+    "    geometry=[\n",
+    "        [\"O\", [0.0, 0.0, 0.0]],\n",
+    "        [\"H\", [H1_x, 0.0, 0.0]],\n",
+    "        [\"H\", [H2_x, H2_y, 0.0]],\n",
+    "    ],\n",
+    "    charge=0,\n",
+    "    multiplicity=1,\n",
+    ")\n",
+    "driver = PySCFDriver.from_molecule(molecule=molecule, basis=\"sto6g\")\n",
     "problem = ElectronicStructureProblem(driver)\n",
     "\n",
     "converter = QubitConverter(JordanWignerMapper())"
@@ -110,13 +118,18 @@
     }
    ],
    "source": [
-    "from qiskit_nature.algorithms.ground_state_solvers import GroundStateEigensolver, NumPyMinimumEigensolverFactory\n",
+    "from qiskit_nature.algorithms.ground_state_solvers import (\n",
+    "    GroundStateEigensolver,\n",
+    "    NumPyMinimumEigensolverFactory,\n",
+    ")\n",
     "\n",
-    "solver = GroundStateEigensolver(converter, NumPyMinimumEigensolverFactory(use_default_filter_criterion=False))\n",
+    "solver = GroundStateEigensolver(\n",
+    "    converter, NumPyMinimumEigensolverFactory(use_default_filter_criterion=False)\n",
+    ")\n",
     "\n",
     "result = solver.solve(problem)\n",
     "\n",
-    "print('Classical energy = ', result.total_energies[0])"
+    "print(\"Classical energy = \", result.total_energies[0])"
    ]
   },
   {
@@ -139,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "orbitals_to_reduce = [0,3]"
+    "orbitals_to_reduce = [0, 3]"
    ]
   },
   {
@@ -173,11 +186,11 @@
    "source": [
     "from entanglement_forging import reduce_bitstrings\n",
     "\n",
-    "bitstrings = [[1,1,1,1,1,0,0],[1,0,1,1,1,0,1],[1,0,1,1,1,1,0]]\n",
+    "bitstrings = [[1, 1, 1, 1, 1, 0, 0], [1, 0, 1, 1, 1, 0, 1], [1, 0, 1, 1, 1, 1, 0]]\n",
     "reduced_bitstrings = reduce_bitstrings(bitstrings, orbitals_to_reduce)\n",
     "\n",
-    "print(f'Bitstrings: {bitstrings}')\n",
-    "print(f'Bitstrings after orbital reduction: {reduced_bitstrings}')"
+    "print(f\"Bitstrings: {bitstrings}\")\n",
+    "print(f\"Bitstrings after orbital reduction: {reduced_bitstrings}\")"
    ]
   },
   {
@@ -218,7 +231,7 @@
    "source": [
     "from qiskit.circuit import Parameter, QuantumCircuit\n",
     "\n",
-    "theta = Parameter('θ')\n",
+    "theta = Parameter(\"θ\")\n",
     "\n",
     "hop_gate = QuantumCircuit(2, name=\"Hop gate\")\n",
     "hop_gate.h(0)\n",
@@ -272,7 +285,12 @@
     }
    ],
    "source": [
-    "theta_1, theta_2, theta_3, theta_4 = Parameter('θ1'), Parameter('θ2'), Parameter('θ3'), Parameter('θ4')\n",
+    "theta_1, theta_2, theta_3, theta_4 = (\n",
+    "    Parameter(\"θ1\"),\n",
+    "    Parameter(\"θ2\"),\n",
+    "    Parameter(\"θ3\"),\n",
+    "    Parameter(\"θ4\"),\n",
+    ")\n",
     "\n",
     "ansatz = QuantumCircuit(5)\n",
     "ansatz.append(hop_gate.to_gate({theta: theta_1}), [0, 1])\n",
@@ -281,7 +299,7 @@
     "ansatz.append(hop_gate.to_gate({theta: theta_3}), [0, 2])\n",
     "ansatz.append(hop_gate.to_gate({theta: theta_4}), [3, 4])\n",
     "\n",
-    "ansatz.draw('text', justify='right', fold=-1)"
+    "ansatz.draw(\"text\", justify=\"right\", fold=-1)"
    ]
   },
   {
@@ -307,6 +325,7 @@
    "outputs": [],
    "source": [
     "from entanglement_forging import Log\n",
+    "\n",
     "Log.VERBOSE = False"
    ]
   },
@@ -318,9 +337,11 @@
    },
    "outputs": [],
    "source": [
-    "backend = Aer.get_backend('statevector_simulator')\n",
+    "backend = Aer.get_backend(\"statevector_simulator\")\n",
     "\n",
-    "config = EntanglementForgedConfig(backend = backend, maxiter = 350, spsa_c0 = 20*np.pi, initial_params=[0,0,0,0])"
+    "config = EntanglementForgedConfig(\n",
+    "    backend=backend, maxiter=350, spsa_c0=20 * np.pi, initial_params=[0, 0, 0, 0]\n",
+    ")"
    ]
   },
   {
@@ -351,7 +372,9 @@
     }
    ],
    "source": [
-    "calc = EntanglementForgedGroundStateSolver(converter, ansatz, reduced_bitstrings, config, orbitals_to_reduce)\n",
+    "calc = EntanglementForgedGroundStateSolver(\n",
+    "    converter, ansatz, reduced_bitstrings, config, orbitals_to_reduce\n",
+    ")\n",
     "res = calc.solve(problem)\n",
     "\n",
     "res"
@@ -421,13 +444,13 @@
     }
    ],
    "source": [
-    "print('Energies (from only one paramset in each iteration):')\n",
+    "print(\"Energies (from only one paramset in each iteration):\")\n",
     "plt.plot([e[0] for e in res.get_energies_history()])\n",
     "plt.show()\n",
-    "print('Schmidts (from only one paramset in each iteration):')\n",
+    "print(\"Schmidts (from only one paramset in each iteration):\")\n",
     "plt.plot([s[0] for s in res.get_schmidts_history()])\n",
     "plt.show()\n",
-    "print('Parameters (from only one paramset in each iteration):')\n",
+    "print(\"Parameters (from only one paramset in each iteration):\")\n",
     "plt.plot([p[0] for p in res.get_parameters_history()])\n",
     "plt.show()"
    ]
@@ -464,6 +487,7 @@
    ],
    "source": [
     "import qiskit.tools.jupyter\n",
+    "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
    ]

--- a/docs/1-tutorials/tutorial_3_H2_arbitrary_hamiltonian.ipynb
+++ b/docs/1-tutorials/tutorial_3_H2_arbitrary_hamiltonian.ipynb
@@ -33,6 +33,7 @@
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
   },
@@ -52,15 +53,20 @@
     "import numpy as np\n",
     "\n",
     "from qiskit.circuit.library import TwoLocal\n",
-    "from qiskit_nature.drivers import PySCFDriver, Molecule\n",
+    "from qiskit_nature.drivers import Molecule\n",
+    "from qiskit_nature.drivers.second_quantization import PySCFDriver\n",
     "from qiskit_nature.problems.second_quantization import ElectronicStructureProblem\n",
     "from qiskit_nature.mappers.second_quantization import JordanWignerMapper\n",
     "from qiskit_nature.converters.second_quantization import QubitConverter\n",
     "\n",
     "import sys\n",
-    "sys.path.append('../../')\n",
-    "from entanglement_forging import (EntanglementForgedConfig, EntanglementForgedDriver,\n",
-    "                                  EntanglementForgedGroundStateSolver)"
+    "\n",
+    "sys.path.append(\"../../\")\n",
+    "from entanglement_forging import (\n",
+    "    EntanglementForgedConfig,\n",
+    "    EntanglementForgedDriver,\n",
+    "    EntanglementForgedGroundStateSolver,\n",
+    ")"
    ]
   },
   {
@@ -80,32 +86,34 @@
    "source": [
     "# Coefficients that define the one-body terms of the Hamiltonain\n",
     "\n",
-    "hcore = np.array([\n",
-    "    [-1.12421758, -0.9652574],\n",
-    "    [-0.9652574,- 1.12421758]\n",
-    "])\n",
+    "hcore = np.array([[-1.12421758, -0.9652574], [-0.9652574, -1.12421758]])\n",
     "\n",
     "# Coefficients that define the two-body terms of the Hamiltonian\n",
-    "mo_coeff = np.array([\n",
-    "    [0.54830202, 1.21832731],\n",
-    "    [0.54830202, -1.21832731]\n",
-    "])\n",
+    "mo_coeff = np.array([[0.54830202, 1.21832731], [0.54830202, -1.21832731]])\n",
     "\n",
     "# Coefficients for the molecular orbitals\n",
     "\n",
-    "eri = np.array([\n",
-    "    [[[0.77460594, 0.44744572], [0.44744572, 0.57187698]],\n",
-    "     [[0.44744572, 0.3009177], [0.3009177, 0.44744572]]],\n",
-    "    [[[0.44744572, 0.3009177], [0.3009177, 0.44744572]],\n",
-    "     [[0.57187698, 0.44744572], [0.44744572, 0.77460594]]]\n",
-    "])\n",
+    "eri = np.array(\n",
+    "    [\n",
+    "        [\n",
+    "            [[0.77460594, 0.44744572], [0.44744572, 0.57187698]],\n",
+    "            [[0.44744572, 0.3009177], [0.3009177, 0.44744572]],\n",
+    "        ],\n",
+    "        [\n",
+    "            [[0.44744572, 0.3009177], [0.3009177, 0.44744572]],\n",
+    "            [[0.57187698, 0.44744572], [0.44744572, 0.77460594]],\n",
+    "        ],\n",
+    "    ]\n",
+    ")\n",
     "\n",
-    "driver = EntanglementForgedDriver(hcore=hcore,\n",
-    "                                  mo_coeff=mo_coeff,\n",
-    "                                  eri=eri,\n",
-    "                                  num_alpha=1,\n",
-    "                                  num_beta=1,\n",
-    "                                  nuclear_repulsion_energy=0.7199689944489797)\n",
+    "driver = EntanglementForgedDriver(\n",
+    "    hcore=hcore,\n",
+    "    mo_coeff=mo_coeff,\n",
+    "    eri=eri,\n",
+    "    num_alpha=1,\n",
+    "    num_beta=1,\n",
+    "    nuclear_repulsion_energy=0.7199689944489797,\n",
+    ")\n",
     "problem = ElectronicStructureProblem(driver)\n",
     "problem.second_q_ops()\n",
     "\n",
@@ -167,9 +175,9 @@
     }
    ],
    "source": [
-    "bitstrings = [[1,0],[0,1]]\n",
+    "bitstrings = [[1, 0], [0, 1]]\n",
     "\n",
-    "ansatz = TwoLocal(2, [], 'cry', [[0,1],[1,0]], reps=1)\n",
+    "ansatz = TwoLocal(2, [], \"cry\", [[0, 1], [1, 0]], reps=1)\n",
     "\n",
     "ansatz.draw()"
    ]
@@ -203,9 +211,12 @@
    "outputs": [],
    "source": [
     "from qiskit import Aer\n",
-    "backend = Aer.get_backend('statevector_simulator')\n",
     "\n",
-    "config = EntanglementForgedConfig(backend=backend, maxiter = 200, initial_params=[0,0.5*np.pi])"
+    "backend = Aer.get_backend(\"statevector_simulator\")\n",
+    "\n",
+    "config = EntanglementForgedConfig(\n",
+    "    backend=backend, maxiter=200, initial_params=[0, 0.5 * np.pi]\n",
+    ")"
    ]
   },
   {
@@ -321,14 +332,14 @@
     }
    ],
    "source": [
-    "print('Energies (from only one paramset in each iteration):')\n",
+    "print(\"Energies (from only one paramset in each iteration):\")\n",
     "plt.plot([e[0] for e in res.get_energies_history()])\n",
     "plt.plot([e[1] for e in res.get_energies_history()[0:-1]])\n",
     "plt.show()\n",
-    "print('Schmidts (from only one paramset in each iteration):')\n",
+    "print(\"Schmidts (from only one paramset in each iteration):\")\n",
     "plt.plot([s[0] for s in res.get_schmidts_history()])\n",
     "plt.show()\n",
-    "print('Parameters (from only one paramset in each iteration):')\n",
+    "print(\"Parameters (from only one paramset in each iteration):\")\n",
     "plt.plot([p[0] for p in res.get_parameters_history()])\n",
     "plt.plot([p[1] for p in res.get_parameters_history()[0:-1]])\n",
     "plt.show()"
@@ -366,6 +377,7 @@
    ],
    "source": [
     "import qiskit.tools.jupyter\n",
+    "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
    ]

--- a/docs/1-tutorials/tutorial_4_H2_qasm_simulator.ipynb
+++ b/docs/1-tutorials/tutorial_4_H2_qasm_simulator.ipynb
@@ -37,6 +37,7 @@
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
   },
@@ -63,7 +64,8 @@
     "from qiskit_nature.converters.second_quantization import QubitConverter\n",
     "\n",
     "import sys\n",
-    "sys.path.append('../../')\n",
+    "\n",
+    "sys.path.append(\"../../\")\n",
     "from entanglement_forging import EntanglementForgedGroundStateSolver\n",
     "from entanglement_forging import EntanglementForgedConfig"
    ]
@@ -88,10 +90,12 @@
    "source": [
     "# We start by setting up the chemical problem.\n",
     "\n",
-    "molecule = Molecule(geometry=[['H', [0., 0., 0.]],\n",
-    "                              ['H', [0., 0., 0.735]]],\n",
-    "                     charge=0, multiplicity=1)\n",
-    "driver = PySCFDriver.from_molecule(molecule, basis='sto3g')\n",
+    "molecule = Molecule(\n",
+    "    geometry=[[\"H\", [0.0, 0.0, 0.0]], [\"H\", [0.0, 0.0, 0.735]]],\n",
+    "    charge=0,\n",
+    "    multiplicity=1,\n",
+    ")\n",
+    "driver = PySCFDriver.from_molecule(molecule, basis=\"sto3g\")\n",
     "problem = ElectronicStructureProblem(driver)\n",
     "problem.second_q_ops()\n",
     "\n",
@@ -99,9 +103,9 @@
     "\n",
     "# Prepare the bitstrings and the ansatz\n",
     "\n",
-    "bitstrings = [[1,0],[0,1]]\n",
+    "bitstrings = [[1, 0], [0, 1]]\n",
     "\n",
-    "ansatz = TwoLocal(2, [], 'cry', [[0,1],[1,0]], reps=1)"
+    "ansatz = TwoLocal(2, [], \"cry\", [[0, 1], [1, 0]], reps=1)"
    ]
   },
   {
@@ -144,8 +148,8 @@
    "source": [
     "from qiskit import Aer\n",
     "\n",
-    "backend = Aer.get_backend('qasm_simulator')\n",
-    "config = EntanglementForgedConfig(backend = backend, copysample_job_size = 100)\n",
+    "backend = Aer.get_backend(\"qasm_simulator\")\n",
+    "config = EntanglementForgedConfig(backend=backend, copysample_job_size=100)\n",
     "\n",
     "calc = EntanglementForgedGroundStateSolver(converter, ansatz, bitstrings, config)\n",
     "res = calc.solve(problem)\n",
@@ -222,13 +226,13 @@
     }
    ],
    "source": [
-    "print('Energies (from only one paramset in each iteration):')\n",
+    "print(\"Energies (from only one paramset in each iteration):\")\n",
     "plt.plot([e[0] for e in res.get_energies_history()])\n",
     "plt.show()\n",
-    "print('Schmidts (from only one paramset in each iteration):')\n",
+    "print(\"Schmidts (from only one paramset in each iteration):\")\n",
     "plt.plot([s[0] for s in res.get_schmidts_history()])\n",
     "plt.show()\n",
-    "print('Parameters (from only one paramset in each iteration):')\n",
+    "print(\"Parameters (from only one paramset in each iteration):\")\n",
     "plt.plot([p[0] for p in res.get_parameters_history()])\n",
     "plt.show()"
    ]
@@ -292,6 +296,7 @@
    ],
    "source": [
     "import qiskit.tools.jupyter\n",
+    "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
    ]

--- a/docs/1-tutorials/tutorial_5_H2_equilibrium_distance.ipynb
+++ b/docs/1-tutorials/tutorial_5_H2_equilibrium_distance.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "import warnings\n",
+    "\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "from matplotlib import pyplot as plt\n",
@@ -32,7 +33,8 @@
     "from qiskit import Aer\n",
     "\n",
     "import sys\n",
-    "sys.path.append('../../')\n",
+    "\n",
+    "sys.path.append(\"../../\")\n",
     "from entanglement_forging import EntanglementForgedVQE\n",
     "from entanglement_forging import EntanglementForgedGroundStateSolver\n",
     "from entanglement_forging import EntanglementForgedConfig"
@@ -56,10 +58,12 @@
     "molecules = []\n",
     "\n",
     "for dist in distances:\n",
-    "    molecule = Molecule(geometry=[['H', [0., 0., 0.]],\n",
-    "                                  ['H', [0., 0., dist]]],\n",
-    "                         charge=0, multiplicity=1)\n",
-    "    molecules = molecules + [molecule] "
+    "    molecule = Molecule(\n",
+    "        geometry=[[\"H\", [0.0, 0.0, 0.0]], [\"H\", [0.0, 0.0, dist]]],\n",
+    "        charge=0,\n",
+    "        multiplicity=1,\n",
+    "    )\n",
+    "    molecules = molecules + [molecule]"
    ]
   },
   {
@@ -94,19 +98,19 @@
     }
    ],
    "source": [
-    "bitstrings = [[1,0],[0,1]]\n",
-    "ansatz = TwoLocal(2, [], 'cry', [[0,1],[1,0]], reps=1)\n",
+    "bitstrings = [[1, 0], [0, 1]]\n",
+    "ansatz = TwoLocal(2, [], \"cry\", [[0, 1], [1, 0]], reps=1)\n",
     "\n",
-    "backend = Aer.get_backend('statevector_simulator')\n",
+    "backend = Aer.get_backend(\"statevector_simulator\")\n",
     "converter = QubitConverter(JordanWignerMapper())\n",
     "\n",
-    "config = EntanglementForgedConfig(backend=backend, maxiter = 100)\n",
+    "config = EntanglementForgedConfig(backend=backend, maxiter=100)\n",
     "calc = EntanglementForgedGroundStateSolver(converter, ansatz, bitstrings, config)\n",
     "\n",
     "energies = []\n",
     "\n",
     "for molecule, distance in zip(molecules, distances):\n",
-    "    driver = PySCFDriver.from_molecule(molecule, basis='sto3g')\n",
+    "    driver = PySCFDriver.from_molecule(molecule, basis=\"sto3g\")\n",
     "    problem = ElectronicStructureProblem(driver)\n",
     "    problem.second_q_ops()\n",
     "    res = calc.solve(problem)\n",
@@ -144,9 +148,9 @@
     }
    ],
    "source": [
-    "plt.plot(distances,energies)\n",
-    "plt.xlabel('Atomic distance (Angstrom)')\n",
-    "plt.ylabel('Energy')\n",
+    "plt.plot(distances, energies)\n",
+    "plt.xlabel(\"Atomic distance (Angstrom)\")\n",
+    "plt.ylabel(\"Energy\")\n",
     "plt.show()"
    ]
   },
@@ -182,6 +186,7 @@
    ],
    "source": [
     "import qiskit.tools.jupyter\n",
+    "\n",
     "%qiskit_version_table\n",
     "%qiskit_copyright"
    ]

--- a/entanglement_forging/core/wrappers/entanglement_forged_ground_state_eigensolver.py
+++ b/entanglement_forging/core/wrappers/entanglement_forged_ground_state_eigensolver.py
@@ -24,7 +24,10 @@ from qiskit.opflow import OperatorBase, PauliSumOp
 from qiskit.quantum_info import Statevector
 from qiskit.result import Result
 from qiskit_nature import ListOrDictType
-from qiskit_nature.algorithms.ground_state_solvers import GroundStateSolver, MinimumEigensolverFactory
+from qiskit_nature.algorithms.ground_state_solvers import (
+    GroundStateSolver,
+    MinimumEigensolverFactory,
+)
 from qiskit_nature.mappers.second_quantization import JordanWignerMapper
 from qiskit_nature.operators.second_quantization import SecondQuantizedOp
 from qiskit_nature.problems.second_quantization import BaseProblem
@@ -161,7 +164,11 @@ class EntanglementForgedGroundStateSolver(GroundStateSolver):
     def get_qubit_operators(
         self,
         problem: BaseProblem,
-        aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+        aux_operators: Optional[
+            ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]
+        ] = None,
     ) -> Tuple[PauliSumOp, Optional[ListOrDictType[PauliSumOp]]]:
         """Gets the operator and auxiliary operators, and transforms the provided auxiliary operators"""
-        raise NotImplementedError("get_qubit_operators has not been implemented in EntanglementForgedGroundStateEigensolver")
+        raise NotImplementedError(
+            "get_qubit_operators has not been implemented in EntanglementForgedGroundStateEigensolver"
+        )

--- a/entanglement_forging/core/wrappers/entanglement_forged_ground_state_eigensolver.py
+++ b/entanglement_forging/core/wrappers/entanglement_forged_ground_state_eigensolver.py
@@ -14,16 +14,20 @@
 
 import time
 import warnings
-from typing import List, Union, Dict
+from typing import List, Union, Dict, Optional, Tuple
 
 import numpy as np
 from qiskit import QuantumCircuit
+from qiskit.algorithms import MinimumEigensolver
 from qiskit.circuit import Instruction
 from qiskit.opflow import OperatorBase, PauliSumOp
 from qiskit.quantum_info import Statevector
 from qiskit.result import Result
-from qiskit_nature.algorithms.ground_state_solvers import GroundStateSolver
+from qiskit_nature import ListOrDictType
+from qiskit_nature.algorithms.ground_state_solvers import GroundStateSolver, MinimumEigensolverFactory
 from qiskit_nature.mappers.second_quantization import JordanWignerMapper
+from qiskit_nature.operators.second_quantization import SecondQuantizedOp
+from qiskit_nature.problems.second_quantization import BaseProblem
 from qiskit_nature.problems.second_quantization.electronic import (
     ElectronicStructureProblem,
 )
@@ -96,24 +100,24 @@ class EntanglementForgedGroundStateSolver(GroundStateSolver):
         forged_operator = ForgedOperator(problem, self.orbitals_to_reduce)
         classical_energies = ClassicalEnergies(problem, self.orbitals_to_reduce)
 
-        solver = EntanglementForgedVQE(
+        self._solver = EntanglementForgedVQE(
             ansatz=self._ansatz,
             bitstrings=self._bitstrings,
             config=self._config,
             forged_operator=forged_operator,
             classical_energies=classical_energies,
         )
-        result = solver.compute_minimum_eigenvalue(forged_operator.h_1_op)
+        result = self._solver.compute_minimum_eigenvalue(forged_operator.h_1_op)
 
         elapsed_time = time.time() - start_time
         Log.log(f"VQE for this problem took {elapsed_time} seconds")
         res = EntanglementForgedVQEResult(
-            parameters_history=solver._paramsets_each_iteration,
-            energies_history=solver._energy_each_iteration_each_paramset,
-            schmidts_history=solver._schmidt_coeffs_each_iteration_each_paramset,
-            energy_std_each_parameter_set=solver.energy_std_each_parameter_set,
-            energy_offset=solver._add_this_to_energies_displayed,
-            eval_count=solver._eval_count,
+            parameters_history=self._solver._paramsets_each_iteration,
+            energies_history=self._solver._energy_each_iteration_each_paramset,
+            schmidts_history=self._solver._schmidt_coeffs_each_iteration_each_paramset,
+            energy_std_each_parameter_set=self._solver.energy_std_each_parameter_set,
+            energy_offset=self._solver._add_this_to_energies_displayed,
+            eval_count=self._solver._eval_count,
         )
         res.combine(result)
         return res
@@ -148,3 +152,16 @@ class EntanglementForgedGroundStateSolver(GroundStateSolver):
             "forged EntanglementForgedGroundStateSolver."
         )
         return []
+
+    @property
+    def solver(self) -> Union[MinimumEigensolver, MinimumEigensolverFactory]:
+        """Returns the minimum eigensolver or factory."""
+        return self._solver
+
+    def get_qubit_operators(
+        self,
+        problem: BaseProblem,
+        aux_operators: Optional[ListOrDictType[Union[SecondQuantizedOp, PauliSumOp]]] = None,
+    ) -> Tuple[PauliSumOp, Optional[ListOrDictType[PauliSumOp]]]:
+        """Gets the operator and auxiliary operators, and transforms the provided auxiliary operators"""
+        raise NotImplementedError("get_qubit_operators has not been implemented in EntanglementForgedGroundStateEigensolver")


### PR DESCRIPTION
New abstract methods in GroundStateSolver caused EFGroundStateSolver to fail instantiation due to those methods not being implemented.

The solver property has been implemented properly.

The get_qubit_operators method will throw a NotImplementedError if called.